### PR TITLE
refactor: update authentication to use delegated access tokens

### DIFF
--- a/src/errors/authError.ts
+++ b/src/errors/authError.ts
@@ -1,0 +1,50 @@
+/**
+ * Custom error class for authentication-related errors
+ */
+export class AuthenticationError extends Error {
+  public readonly code: string;
+  public readonly details?: Record<string, unknown>;
+  public readonly remediation?: string;
+
+  constructor(
+    code: string,
+    message: string,
+    remediation?: string,
+    details?: Record<string, unknown>
+  ) {
+    super(message);
+    this.name = 'AuthenticationError';
+    this.code = code;
+    this.remediation = remediation;
+    this.details = details;
+
+    // Set the prototype explicitly for proper instanceof checks
+    Object.setPrototypeOf(this, AuthenticationError.prototype);
+  }
+
+  /**
+   * Converts the error to a JSON-serializable object
+   */
+  public toJSON() {
+    return {
+      error: this.code,
+      message: this.message,
+      ...(this.remediation && { remediation: this.remediation }),
+      ...(this.details && { details: this.details }),
+      stack: this.stack
+    };
+  }
+
+  /**
+   * Logs the error to the console with appropriate formatting
+   */
+  public log() {
+    console.error(`[AuthenticationError: ${this.code}] ${this.message}`);
+    if (this.remediation) {
+      console.error(`Remediation: ${this.remediation}`);
+    }
+    if (this.details) {
+      console.error('Details:', this.details);
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,84 +3,31 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 // @ts-ignore - Missing type definitions for @modelcontextprotocol/sdk
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerPlannerTools } from './tools/plannerTools.js';
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
-
-// Get the directory name of the current module
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Load environment variables from .env file in the project root
-const envPath = path.resolve(__dirname, '../../.env');
-dotenv.config({ path: envPath });
-
-// Check for required environment variables
-const requiredEnvVars = ["AZURE_TENANT_ID", "AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET"];
-const missingVars = requiredEnvVars.filter((varName) => !process.env[varName]);
-
-if (missingVars.length > 0) {
-  // Error messages removed for production
-  process.exit(1);
-}
-
-// Environment variables loaded
 
 // Create server instance
 const server = new McpServer({
   name: "ms-planner",
   version: "1.0.0",
+  description: "Microsoft Planner Integration"
 });
 
 // Register tools
 registerPlannerTools(server);
 
-// Store the original console methods
-const originalConsole = {
-  log: console.log,
-  error: console.error,
-  warn: console.warn,
-  info: console.info,
-  debug: console.debug
-};
-
-// Suppress all console output during server initialization
-function suppressConsole() {
-  console.log = () => {};
-  console.error = () => {};
-  console.warn = () => {};
-  console.info = () => {};
-  console.debug = () => {};
-}
-
-// Restore original console methods
-function restoreConsole() {
-  console.log = originalConsole.log;
-  console.error = originalConsole.error;
-  console.warn = originalConsole.warn;
-  console.info = originalConsole.info;
-  console.debug = originalConsole.debug;
-}
-
 // Start the server
 async function main() {
   try {
-    // Suppress console output during server initialization
-    suppressConsole();
-    
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    
-    // Restore console after successful connection
-    restoreConsole();
+    console.error("MCP Planner Server running on stdio");
   } catch (error) {
-    // Restore console before exiting on error
-    restoreConsole();
+    console.error('Failed to start server:', error);
     process.exit(1);
   }
 }
 
 // Start the server
-main().catch(() => {
+main().catch((error) => {
+  console.error('Unhandled error in main:', error);
   process.exit(1);
 });

--- a/src/schemas/createPlannerTaskSchema.ts
+++ b/src/schemas/createPlannerTaskSchema.ts
@@ -1,16 +1,11 @@
 import { z } from 'zod';
+import { authSchema } from './fetchPlannerTasksSchema.js';
 
 /**
  * Schema for creating a new Planner task
  * Only includes essential fields for task creation
  */
-export const createPlannerTaskSchema = z.object({
-  /**
-   * The ID of the user to assign the task to
-   * Use "me" to assign to the current user (default)
-   * Or provide a specific user ID
-   */
-  userId: z.string().default('me'),
+export const createPlannerTaskSchema = authSchema.extend({
   /**
    * The ID of the plan to add the task to
    * Default: A default plan ID will be used if not provided

--- a/src/schemas/fetchPlannerTasksSchema.ts
+++ b/src/schemas/fetchPlannerTasksSchema.ts
@@ -1,15 +1,25 @@
 import { z } from 'zod';
 
 /**
+ * Base authentication schema that requires an access token
+ */
+export const authSchema = z.object({
+  /**
+   * Access token obtained through OAuth 2.0 authentication
+   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+   */
+  accessToken: z.string({
+    required_error: 'Access token is required',
+    invalid_type_error: 'Access token must be a string',
+  })
+  .min(1, 'Access token cannot be empty')
+  .describe('A valid OAuth 2.0 access token obtained through user authentication')
+});
+
+/**
  * Schema for fetching planner tasks with optional filtering parameters
  */
-export const fetchPlannerTasksSchema = z.object({
-  /**
-   * The ID of the user whose tasks to fetch. Use 'me' for the current user.
-   * If not provided, it will use the USER_ID from environment variables.
-   */
-  user_id: z.string().optional().default('me'),
-  
+export const fetchPlannerTasksSchema = authSchema.extend({
   /**
    * Filter tasks by status. Status is mapped to percentComplete:
    * - 'notStarted': Tasks with 0% complete (percentComplete = 0)
@@ -26,4 +36,15 @@ export const fetchPlannerTasksSchema = z.object({
 /**
  * Input type for fetching planner tasks
  */
+/**
+ * Input type for fetching planner tasks
+ */
 export type FetchPlannerTasksInput = z.infer<typeof fetchPlannerTasksSchema>;
+
+/**
+ * Authentication configuration type
+ */
+export type AuthConfig = {
+  accessToken: string;
+  expiresIn?: number;
+};


### PR DESCRIPTION
## Changes
- Update authentication to use delegated access tokens instead of application permissions
- Remove direct Azure credential usage in favor of token-based authentication
- Update Microsoft Graph client initialization to use the v3.x auth provider pattern
- Add proper error handling for authentication failures

## Testing
- [ ] Verify planner tasks can be fetched with a valid access token
- [ ] Test task creation with the new authentication flow
- [ ] Ensure all existing functionality works with the updated authentication

## Related Issues
- Part of the broader effort to move away from application permissions to delegated permissions

## Notes
- This change aligns with our security best practices by using the principle of least privilege
- The service now expects an access token to be provided with each request